### PR TITLE
Add interactive CLI for ChatGPT conversation history

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,13 @@ npm run chat -- "Hello, ChatGPT!"
 ```
 
 The ChatGPT response will be printed to the console.
+
+### Interactive conversation
+
+You can also start an interactive session that keeps track of the conversation history:
+
+```bash
+npm run interactive
+```
+
+Type messages and press <kbd>Enter</kbd>. Use `exit` to quit the session.

--- a/interactive.js
+++ b/interactive.js
@@ -1,0 +1,38 @@
+const readline = require('readline');
+const OpenAI = require('openai');
+const client = new OpenAI();
+
+const messages = [];
+
+async function sendPrompt(prompt) {
+  messages.push({ role: 'user', content: prompt });
+  const completion = await client.chat.completions.create({
+    model: 'gpt-4o',
+    messages,
+  });
+  const response = completion.choices[0].message.content.trim();
+  console.log(response);
+  messages.push({ role: 'assistant', content: response });
+}
+
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+console.log('Start chatting with ChatGPT (type "exit" to quit):');
+rl.setPrompt('> ');
+rl.prompt();
+
+rl.on('line', async (line) => {
+  const input = line.trim();
+  if (input.toLowerCase() === 'exit') {
+    rl.close();
+    return;
+  }
+  try {
+    await sendPrompt(input);
+  } catch (err) {
+    console.error('ChatGPT request failed:', err.message);
+  }
+  rl.prompt();
+}).on('close', () => {
+  console.log('Goodbye!');
+  process.exit(0);
+});

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "openai": "^5.9.0"
   },
   "scripts": {
-    "chat": "node index.js"
+    "chat": "node index.js",
+    "interactive": "node interactive.js"
   }
 }


### PR DESCRIPTION
## Summary
- implement `interactive.js` for multi-turn conversations
- document interactive usage in README
- add `interactive` npm script

## Testing
- `npm test` *(fails: Missing script)*
- `node interactive.js` *(fails: Connection error)*

------
https://chatgpt.com/codex/tasks/task_e_6870eb954f04832a9ddf49c3101e13f1