### PR TITLE
Add integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,10 @@ npm run interactive
 ```
 
 Type messages and press <kbd>Enter</kbd>. Use `exit` to quit the session.
+
+## Next Steps
+
+Once you are comfortable running the basic scripts, you can reuse the same ChatGPT calls in other contexts. See [docs/integration.md](docs/integration.md) for examples of:
+
+- Adding a web API endpoint with Express
+- Embedding the `chat` function in your own CLI tool

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,0 +1,70 @@
+# Integrating ChatGPT into Your Application
+
+This project provides a minimal example of using the `openai` Node.js package to talk to ChatGPT. Once you are comfortable running the basic scripts, you can incorporate the same logic into other contexts, such as a web server or custom CLI tool.
+
+## Web Backend (Express Example)
+
+Install `express` in your project:
+
+```bash
+npm install express
+```
+
+Create a small server (e.g. `server.js`):
+
+```javascript
+const express = require('express');
+const OpenAI = require('openai');
+const client = new OpenAI();
+
+const app = express();
+app.use(express.json());
+
+app.post('/chat', async (req, res) => {
+  try {
+    const userMessage = req.body.message;
+    const completion = await client.chat.completions.create({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: userMessage }],
+    });
+    res.json({ response: completion.choices[0].message.content.trim() });
+  } catch (err) {
+    console.error('ChatGPT request failed:', err);
+    res.status(500).json({ error: 'Failed to get response from ChatGPT' });
+  }
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => console.log(`Server listening on port ${port}`));
+```
+
+Run it with:
+
+```bash
+node server.js
+```
+
+You can then send POST requests with a JSON body `{ "message": "Your prompt" }` to `http://localhost:3000/chat`.
+
+## CLI Tool Integration
+
+To integrate into a larger CLI, you can require the `index.js` logic and call the `chat` function from your own command definitions. Use a library like [`commander`](https://www.npmjs.com/package/commander) or [`yargs`](https://www.npmjs.com/package/yargs`) to define commands, then pass prompts from the command line to ChatGPT.
+
+Example snippet using `commander`:
+
+```javascript
+const { Command } = require('commander');
+const { chat } = require('./index'); // export chat from index.js
+
+const program = new Command();
+program
+  .command('ask <prompt>')
+  .description('Send a prompt to ChatGPT')
+  .action(async (prompt) => {
+    await chat(prompt);
+  });
+
+program.parse(process.argv);
+```
+
+This approach allows you to build a full-featured CLI with multiple subcommands while reusing the ChatGPT logic from this project.

--- a/index.js
+++ b/index.js
@@ -13,10 +13,13 @@ async function chat(prompt) {
   }
 }
 
-const prompt = process.argv.slice(2).join(' ');
-if (!prompt) {
-  console.error('Usage: node index.js <your prompt>');
-  process.exit(1);
+if (require.main === module) {
+  const prompt = process.argv.slice(2).join(' ');
+  if (!prompt) {
+    console.error('Usage: node index.js <your prompt>');
+    process.exit(1);
+  }
+  chat(prompt);
 }
 
-chat(prompt);
+module.exports = { chat };


### PR DESCRIPTION
## Summary
- export the `chat` function from `index.js` for reuse
- document next steps in `README` with a link to a new integration guide
- add `docs/integration.md` showing Express server and CLI examples

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6870f2fc4d44832aad1cccadd2ee58f9