### PR TITLE
Add dotenv environment management

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ This project demonstrates a minimal ChatGPT integration using the [openai](https
 
 ## Prerequisites
 
-Set your OpenAI API key in the `OPENAI_API_KEY` environment variable.
+Create a `.env` file and set your OpenAI API key in it:
 
 ```bash
-export OPENAI_API_KEY=your-key
+echo "OPENAI_API_KEY=your-key" > .env
 ```
+
+The script loads this file automatically using [dotenv](https://www.npmjs.com/package/dotenv).
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const OpenAI = require('openai');
+require('dotenv').config();
 const client = new OpenAI();
 
 async function chat(prompt) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,20 @@
   "packages": {
     "": {
       "dependencies": {
+        "dotenv": "^17.2.0",
         "openai": "^5.9.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.0.tgz",
+      "integrity": "sha512-Q4sgBT60gzd0BB0lSyYD3xM4YxrXA9y4uBDof1JNYGzOXrQdQ6yX+7XIAqoFOGQFOTK1D3Hts5OllpxMDZFONQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/openai": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "dotenv": "^17.2.0",
     "openai": "^5.9.0"
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- integrate `dotenv` for easier environment variable management
- mention `.env` in README

## Testing
- `npm run chat -- "Hello"` *(fails: APIConnectionError)*

------
https://chatgpt.com/codex/tasks/task_e_6870fa1a3094832a8f5031ca7913d724