### PR TITLE
Add environment-based parameter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,17 @@ npm run interactive
 ```
 
 Type messages and press Enter to send them. Use `exit` to quit.
+
+## API Configuration
+
+You can adjust request parameters like `model` and `temperature` via environment
+variables. Set them in your `.env` file:
+
+```bash
+echo "OPENAI_MODEL=gpt-4o" >> .env
+echo "OPENAI_TEMPERATURE=0.7" >> .env
+```
+
+These values are passed directly to `client.chat.completions.create`. See the
+[Chat Completions API docs](https://platform.openai.com/docs/api-reference/chat/create)
+for details on available parameters.

--- a/cli.js
+++ b/cli.js
@@ -4,6 +4,11 @@ const readline = require('readline');
 
 const client = new OpenAI();
 
+const model = process.env.OPENAI_MODEL || 'gpt-4o';
+const temperature = process.env.OPENAI_TEMPERATURE
+  ? parseFloat(process.env.OPENAI_TEMPERATURE)
+  : undefined;
+
 async function startChat() {
   const rl = readline.createInterface({
     input: process.stdin,
@@ -25,8 +30,9 @@ async function startChat() {
     messages.push({ role: 'user', content: input });
     try {
       const completion = await client.chat.completions.create({
-        model: 'gpt-4o',
-        messages
+        model,
+        messages,
+        temperature,
       });
 
       const response = completion.choices[0].message.content.trim();

--- a/index.js
+++ b/index.js
@@ -2,11 +2,17 @@ const OpenAI = require('openai');
 require('dotenv').config();
 const client = new OpenAI();
 
+const model = process.env.OPENAI_MODEL || 'gpt-4o';
+const temperature = process.env.OPENAI_TEMPERATURE
+  ? parseFloat(process.env.OPENAI_TEMPERATURE)
+  : undefined;
+
 async function chat(prompt) {
   try {
     const completion = await client.chat.completions.create({
-      model: 'gpt-4o',
+      model,
       messages: [{ role: 'user', content: prompt }],
+      temperature,
     });
     console.log(completion.choices[0].message.content.trim());
   } catch (err) {


### PR DESCRIPTION
## Summary
- add `model` and `temperature` environment variable support for chat scripts
- document how to adjust parameters in README

## Testing
- `npm run chat -- "Hello"`
- `npm run interactive <<'EOF'
exit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6870ffc93220832a823c786bee0f50c7