### PR TITLE
Improve ChatGPT error handling with retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ variables. Set them in your `.env` file:
 ```bash
 echo "OPENAI_MODEL=gpt-4o" >> .env
 echo "OPENAI_TEMPERATURE=0.7" >> .env
+echo "OPENAI_MAX_RETRIES=3" >> .env
 ```
+The `OPENAI_MAX_RETRIES` value controls how many times the scripts retry a
+failed API request before giving up.
 
 These values are passed directly to `client.chat.completions.create`. See the
 [Chat Completions API docs](https://platform.openai.com/docs/api-reference/chat/create)

--- a/cli.js
+++ b/cli.js
@@ -4,10 +4,27 @@ const readline = require('readline');
 
 const client = new OpenAI();
 
+const maxRetries = parseInt(process.env.OPENAI_MAX_RETRIES || '3', 10);
+
 const model = process.env.OPENAI_MODEL || 'gpt-4o';
 const temperature = process.env.OPENAI_TEMPERATURE
   ? parseFloat(process.env.OPENAI_TEMPERATURE)
   : undefined;
+
+async function createCompletionWithRetry(options) {
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      return await client.chat.completions.create(options);
+    } catch (err) {
+      console.error(`ChatGPT request failed (attempt ${attempt}/${maxRetries}):`, err);
+      if (attempt === maxRetries) {
+        throw err;
+      }
+      const delay = 1000 * attempt;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+}
 
 async function startChat() {
   const rl = readline.createInterface({
@@ -29,7 +46,7 @@ async function startChat() {
 
     messages.push({ role: 'user', content: input });
     try {
-      const completion = await client.chat.completions.create({
+      const completion = await createCompletionWithRetry({
         model,
         messages,
         temperature,
@@ -39,7 +56,7 @@ async function startChat() {
       console.log(response);
       messages.push({ role: 'assistant', content: response });
     } catch (err) {
-      console.error('ChatGPT request failed:', err);
+      console.error(`ChatGPT request failed after ${maxRetries} attempts:`, err);
     }
 
     rl.prompt();

--- a/index.js
+++ b/index.js
@@ -2,21 +2,38 @@ const OpenAI = require('openai');
 require('dotenv').config();
 const client = new OpenAI();
 
+const maxRetries = parseInt(process.env.OPENAI_MAX_RETRIES || '3', 10);
+
 const model = process.env.OPENAI_MODEL || 'gpt-4o';
 const temperature = process.env.OPENAI_TEMPERATURE
   ? parseFloat(process.env.OPENAI_TEMPERATURE)
   : undefined;
 
+async function createCompletionWithRetry(options) {
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      return await client.chat.completions.create(options);
+    } catch (err) {
+      console.error(`ChatGPT request failed (attempt ${attempt}/${maxRetries}):`, err);
+      if (attempt === maxRetries) {
+        throw err;
+      }
+      const delay = 1000 * attempt;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+}
+
 async function chat(prompt) {
   try {
-    const completion = await client.chat.completions.create({
+    const completion = await createCompletionWithRetry({
       model,
       messages: [{ role: 'user', content: prompt }],
       temperature,
     });
     console.log(completion.choices[0].message.content.trim());
   } catch (err) {
-    console.error('ChatGPT request failed:', err);
+    console.error(`ChatGPT request failed after ${maxRetries} attempts:`, err);
   }
 }
 


### PR DESCRIPTION
## Summary
- add configurable retry logic to `index.js`
- add same retry handling for interactive chat in `cli.js`
- document `OPENAI_MAX_RETRIES` setting in the README

## Testing
- `node index.js 'test'` *(fails: APIConnectionError)*
- `echo 'exit' | node cli.js`

------
https://chatgpt.com/codex/tasks/task_e_687102c2b89c832a99b07beffa17eaed