### PR TITLE
Add persistent chat history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+history.json

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ npm run interactive
 ```
 
 Type messages and press Enter to send them. Use `exit` to quit.
+Conversation history is saved to `history.json` in the project root. Set
+`OPENAI_HISTORY_FILE` in your `.env` file to use a different path.
 
 ## API Configuration
 
@@ -41,6 +43,7 @@ variables. Set them in your `.env` file:
 echo "OPENAI_MODEL=gpt-4o" >> .env
 echo "OPENAI_TEMPERATURE=0.7" >> .env
 echo "OPENAI_MAX_RETRIES=3" >> .env
+echo "OPENAI_HISTORY_FILE=history.json" >> .env
 ```
 The `OPENAI_MAX_RETRIES` value controls how many times the scripts retry a
 failed API request before giving up.

--- a/cli.js
+++ b/cli.js
@@ -1,6 +1,7 @@
 const OpenAI = require('openai');
 require('dotenv').config();
 const readline = require('readline');
+const fs = require('fs');
 
 const client = new OpenAI();
 
@@ -10,6 +11,7 @@ const model = process.env.OPENAI_MODEL || 'gpt-4o';
 const temperature = process.env.OPENAI_TEMPERATURE
   ? parseFloat(process.env.OPENAI_TEMPERATURE)
   : undefined;
+const historyPath = process.env.OPENAI_HISTORY_FILE || 'history.json';
 
 async function createCompletionWithRetry(options) {
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
@@ -33,7 +35,23 @@ async function startChat() {
     prompt: '> '
   });
 
-  const messages = [];
+  let messages = [];
+  if (fs.existsSync(historyPath)) {
+    try {
+      messages = JSON.parse(fs.readFileSync(historyPath, 'utf8'));
+    } catch (err) {
+      console.error('Failed to load history:', err);
+      messages = [];
+    }
+  }
+
+  function saveHistory() {
+    try {
+      fs.writeFileSync(historyPath, JSON.stringify(messages, null, 2));
+    } catch (err) {
+      console.error('Failed to save history:', err);
+    }
+  }
   console.log('Start chatting with ChatGPT (type "exit" to quit)');
   rl.prompt();
 
@@ -45,6 +63,7 @@ async function startChat() {
     }
 
     messages.push({ role: 'user', content: input });
+    saveHistory();
     try {
       const completion = await createCompletionWithRetry({
         model,
@@ -55,6 +74,7 @@ async function startChat() {
       const response = completion.choices[0].message.content.trim();
       console.log(response);
       messages.push({ role: 'assistant', content: response });
+      saveHistory();
     } catch (err) {
       console.error(`ChatGPT request failed after ${maxRetries} attempts:`, err);
     }
@@ -63,6 +83,7 @@ async function startChat() {
   });
 
   rl.on('close', () => {
+    saveHistory();
     console.log('Chat ended');
     process.exit(0);
   });


### PR DESCRIPTION
## Summary
- save interactive conversation history to disk
- document new OPENAI_HISTORY_FILE setting
- ignore generated history.json file

## Testing
- `OPENAI_API_KEY=dummy node cli.js <<'EOF'
exit
EOF`
- `OPENAI_API_KEY=dummy node cli.js <<'EOF'
hello
exit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687104272f44832ab9cc035dbc02ad41