### PR TITLE
Improve dotenv documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 history.json
+.env

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ echo "OPENAI_API_KEY=your-key" > .env
 
 The script loads this file automatically using [dotenv](https://www.npmjs.com/package/dotenv).
 
+## Environment Management
+
+Configuration values such as your API key are stored in a local `.env` file.
+When the application starts, `require('dotenv').config()` reads this file and
+places each `KEY=value` pair into `process.env`. Your code can then access the
+OpenAI key via `process.env.OPENAI_API_KEY` without exposing it in the source
+code. Because `.env` is ignored by git, the key remains on your machine and
+doesn't get committed to the repository.
+
 ## Usage
 
 Install dependencies (already installed in this environment) and run the script with your prompt:

--- a/cli.js
+++ b/cli.js
@@ -1,4 +1,6 @@
 const OpenAI = require('openai');
+// Load variables from the .env file so your API key and other settings remain
+// outside the codebase.
 require('dotenv').config();
 const readline = require('readline');
 const fs = require('fs');

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 const OpenAI = require('openai');
+// Load environment variables from the local .env file so secrets aren't
+// hard-coded. Variables like OPENAI_API_KEY become available on process.env.
 require('dotenv').config();
 const client = new OpenAI();
 


### PR DESCRIPTION
## Summary
- document how dotenv handles secrets
- ignore `.env` in git
- clarify environment loading in `index.js` and `cli.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6871075e2068832a9f37fa6e4bc9f5d2