### PR TITLE
Update example.mjs to use chat completions and embeddings

### DIFF
--- a/example.mjs
+++ b/example.mjs
@@ -7,3 +7,17 @@ const response = await client.responses.create({
 });
 
 console.log(response.output_text);
+
+const chatCompletion = await client.chat.completions.create({
+    model: "gpt-3.5-turbo",
+    messages: [{ role: "user", content: "Say hello to a new user." }]
+});
+
+console.log(chatCompletion.choices[0].message.content);
+
+const embedding = await client.embeddings.create({
+    model: "text-embedding-3-small",
+    input: "OpenAI provides a powerful API."
+});
+
+console.log(embedding.data[0].embedding.length);


### PR DESCRIPTION
## Summary
- expand `example.mjs` to call additional API endpoints

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687f475ba3a0832a9473435ef03301a1